### PR TITLE
Add explicit cast to char*

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -275,7 +275,7 @@ static int get_dir(lua_State * L)
   size_t size = LFS_MAXPATHLEN; /* initial buffer size */
   int result;
   while (1) {
-    char *path2 = realloc(path, size);
+    char *path2 = (char*)realloc(path, size);
     if (!path2) {               /* failed to allocate */
       result = pusherror(L, "get_dir realloc() failed");
       break;
@@ -1065,7 +1065,7 @@ static int push_link_target(lua_State * L)
   int tsize, size = 256;        /* size = initial buffer capacity */
   int ok = 0;
   while (!ok) {
-    char *target2 = realloc(target, size);
+    char *target2 = (char*)realloc(target, size);
     if (!target2) {             /* failed to allocate */
       break;
     }


### PR DESCRIPTION
When I compile Lua as C++ (and therefore need to compile lfs as C++ as well), GCC says this:

```
luafilesystem/src/lfs.c:1068:28: error: invalid conversion from ‘void*’ to ‘char*’ [-fpermissive]
 1068 |     char *target2 = realloc(target, size);
      |                     ~~~~~~~^~~~~~~~~~~~~~
      |                            |
      |                            void*
```

To fix this, explicit cast to `char*` is needed. (lfs compiles as C++ and works well after this patch)

P.S. [here](https://github.com/ThePhD/sol2/issues/739) is why I compile Lua as C++