### PR TITLE
Explicitly cast void * pointers - allows code to build cleanly as C++

### DIFF
--- a/src/lfs.c
+++ b/src/lfs.c
@@ -275,7 +275,7 @@ static int get_dir(lua_State * L)
   size_t size = LFS_MAXPATHLEN; /* initial buffer size */
   int result;
   while (1) {
-    char *path2 = realloc(path, size);
+    char *path2 = (char *)realloc(path, size);
     if (!path2) {               /* failed to allocate */
       result = pusherror(L, "get_dir realloc() failed");
       break;
@@ -1065,7 +1065,7 @@ static int push_link_target(lua_State * L)
   int tsize, size = 256;        /* size = initial buffer capacity */
   int ok = 0;
   while (!ok) {
-    char *target2 = realloc(target, size);
+    char *target2 = (char *)realloc(target, size);
     if (!target2) {             /* failed to allocate */
       break;
     }


### PR DESCRIPTION
This allows LuaFileSystem to build cleanly as C++ without needing `-fpermissive` or similar.  This is useful when Lua itself is built as C++ to support unwinding locals when raising errors from Lua CFunctions implemented in C++.